### PR TITLE
Don't exclude .gitignore

### DIFF
--- a/s3deploy.sh
+++ b/s3deploy.sh
@@ -331,7 +331,7 @@ s3d_initialize() {
         fi
 
         # Install the aws cli tools
-        pip install $user_mode $ignore_installed awscli==1.7.14
+        pip install $user_mode $ignore_installed awscli==1.7.31
 
         # Update the path to access the aws executable
         if [ -z "$TRAVIS_PYTHON_VERSION" ]; then export PATH="$HOME/.local/bin/:$PATH"; fi

--- a/s3deploy.sh
+++ b/s3deploy.sh
@@ -251,7 +251,7 @@ s3d_upload() {
 
     if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ -z "$TRAVIS_TAG" ]; then
         # tar --exclude-vcs $TARBALL_EXCLUDE_PATHS -c -z -f "$TARBALL_TARGET_PATH" .
-        tar $TARBALL_EXCLUDE_PATHS -c -z -f "$TARBALL_TARGET_PATH" .
+        tar --exclude='./.git' $TARBALL_EXCLUDE_PATHS -c -z -f "$TARBALL_TARGET_PATH" .
 
         # Get sha256 checksum  # Converts the md5sum hex string output to raw bytes and converts that to base64
         TARBALL_CHECKSUM=$(cat $TARBALL_TARGET_PATH | sha256sum | cut -b 1-64) # | sed 's/\([0-9A-F]\{2\}\)/\\\\\\x\1/gI' | xargs printf | base64)

--- a/s3deploy.sh
+++ b/s3deploy.sh
@@ -123,8 +123,10 @@ _check_build_exists() {
         if [ "$?" -eq 0 ]; then
             set -e
             echo "Commit $TRAVIS_COMMIT has already been built. Copying from $branch to $TRAVIS_BRANCH, then exiting build.";
-            aws s3 cp "s3://$AWS_S3_BUCKET/$s3_path" "s3://$AWS_S3_BUCKET/$AWS_S3_OBJECT_PATH"
-            aws s3 cp "s3://$AWS_S3_BUCKET/$s3_path" "s3://$AWS_S3_BUCKET/$GIT_REPO_NAME/$TRAVIS_BRANCH/latest.tar.gz"
+            # aws s3 cp "s3://$AWS_S3_BUCKET/$s3_path" "s3://$AWS_S3_BUCKET/$AWS_S3_OBJECT_PATH"
+            # aws s3 cp "s3://$AWS_S3_BUCKET/$s3_path" "s3://$AWS_S3_BUCKET/$GIT_REPO_NAME/$TRAVIS_BRANCH/latest.tar.gz"
+            aws s3api copy-object --metadata-directive COPY --copy-source "$AWS_S3_BUCKET/$s3_path" --bucket "$AWS_S3_BUCKET" --key "$AWS_S3_OBJECT_PATH"
+            aws s3api copy-object --metadata-directive COPY --copy-source "$AWS_S3_BUCKET/$s3_path" --bucket "$AWS_S3_BUCKET" --key "$GIT_REPO_NAME/$TRAVIS_BRANCH/latest.tar.gz"
 
             # Create git tag
             if [[ "$TRAVIS_BRANCH" =~ $TAG_ON ]]; then _create_git_tag; fi
@@ -260,7 +262,8 @@ s3d_upload() {
         TARBALL_ETAG=`ruby -e "require 'json'; resp = JSON.parse(%x[aws s3api put-object --acl private --bucket $AWS_S3_BUCKET --key $AWS_S3_OBJECT_PATH --body $TARBALL_TARGET_PATH --metadata revision=$TRAVIS_COMMIT]); puts resp['ETag'][1..-2]"`
 
         # Upadate latest tarball
-        aws s3 cp "s3://$AWS_S3_BUCKET/$AWS_S3_OBJECT_PATH" "s3://$AWS_S3_BUCKET/$GIT_REPO_NAME/$TRAVIS_BRANCH/latest.tar.gz"
+        # aws s3 cp "s3://$AWS_S3_BUCKET/$AWS_S3_OBJECT_PATH" "s3://$AWS_S3_BUCKET/$GIT_REPO_NAME/$TRAVIS_BRANCH/latest.tar.gz"
+        aws s3api copy-object --metadata-directive COPY --copy-source "$AWS_S3_BUCKET/$AWS_S3_OBJECT_PATH" --bucket "$AWS_S3_BUCKET" --key "$GIT_REPO_NAME/$TRAVIS_BRANCH/latest.tar.gz"
 
         # Create git tag
         if [[ "$TRAVIS_BRANCH" =~ $TAG_ON ]]; then _create_git_tag; fi


### PR DESCRIPTION
Because it breaks bundler 1.10.x

Update aws cli to 1.7.31
Update to insert revision metadata and use aws s3api copy-object instead of s3 cp because it will copy the metadata over