### PR TITLE
Exit 0 instead of 1 when AWS secret key not available

### DIFF
--- a/s3deploy.sh
+++ b/s3deploy.sh
@@ -208,7 +208,7 @@ s3d_initialize() {
 
     set +x
     # we don't want to spew the secrets
-    if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then echo "AWS_SECRET_ACCESS_KEY not set"; exit 1; fi
+    if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then echo "AWS_SECRET_ACCESS_KEY not set"; exit 0; fi
     set -x
 
     # Enable user install if virtualenv has not been activated


### PR DESCRIPTION
This supports builds for PRs where the source is not an OG repo.

@Chili-Man This is the change you suggested. Let me know if something else should change. I can push up a 4.2.1 tag after merge if this looks good.